### PR TITLE
Improve error message for invalid workflow version

### DIFF
--- a/src/hugo.ts
+++ b/src/hugo.ts
@@ -175,7 +175,7 @@ export class Hugo {
         // Check if version is valid
         if (version === null) {
             if (process.env.alfred_debug === '1') {
-                console.error(`Invalid workflow version: ${process.env.alfred_workflow_version}`);
+                console.error(`Invalid workflow version: ${process.env.alfred_workflow_version}. Open your workflow in Alfred, click on the [x]-Symbol and set a semantic version number.`);
             }
 
             version = undefined;

--- a/test/meta/workflow.ts
+++ b/test/meta/workflow.ts
@@ -52,7 +52,7 @@ test.serial("no version", (t) => {
 
     t.is(typeof h.workflowMeta, "object");
     t.falsy(h.workflowMeta.version);
-    t.true(consoleStub.calledWith("Invalid workflow version: undefined"));
+    t.true(consoleStub.calledWith(sinon.match("Invalid workflow version: undefined")));
 });
 
 test.serial("invalid version", (t) => {
@@ -72,7 +72,7 @@ test.serial("invalid version", (t) => {
 
     t.is(typeof h.workflowMeta, "object");
     t.falsy(h.workflowMeta.version);
-    t.true(consoleStub.calledWith("Invalid workflow version: foobar"));
+    t.true(consoleStub.calledWith(sinon.match("Invalid workflow version: foobar")));
 });
 
 test.afterEach.always(() => {


### PR DESCRIPTION
When I generated a blank workflow using Alfred itself, no default version number was set in the `Info.plist`. Therefore, I always got the error message 'Invalid workflow version: undefined'. Being new to Alfred Workflows, it took me a while to figure out what was wrong. In the end, I examined other Workflows and found the missing entry in the `Info.plist`. I added that manually and it worked. Only afterwards did I discover, where you can set the version number using Alfred.

TL;DR – I made the error message a little more helpful, so other Newbies don't fall in the same trap.